### PR TITLE
Mark the module as typed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,7 @@ install_requires =
 [options.packages.find]
 exclude =
     tests*
+
+[options.package_data]
+strong_typing=
+    py.typed


### PR DESCRIPTION
As per PEP-561, we need to include py.typed file in order to mypy consider this package typed.
https://dev.to/whtsky/don-t-forget-py-typed-for-your-typed-python-package-2aa3
