### PR TITLE
Fix error of getting wrong deserializer from cache

### DIFF
--- a/strong_typing/deserializer.py
+++ b/strong_typing/deserializer.py
@@ -838,7 +838,7 @@ def _get_deserializer(typ: TypeLike, context: Optional[ModuleType]) -> Deseriali
     typ = unwrap_annotated_type(typ) if is_type_annotated(typ) else typ
 
     if isinstance(typ, type):
-        cache_key = (typ.__module__, typ.__name__)
+        cache_key = (typ.__module__, str(typ))
 
     if cache_key is not None:
         deserializer = _CACHE.get(cache_key)


### PR DESCRIPTION
The following code
```python
from dataclasses import dataclass
from strong_typing.serialization import json_to_object

@dataclass
class A:
    list_of_str: list[str]
    list_of_dict: list[dict[str, str]]

obj = json_to_object(A, {
    'list_of_str': ['123'],
    'list_of_dict': [{'a': 'a'}]
})
```
will raise the following error:
```
strong_typing.exception.JsonTypeError: `str` type expects JSON `string` data but instead received: {'a': 'a'}
```
The cause is when getting the deserializer for `list_of_str` field, that deserializer will be stored in the `_CACHE` object with the key of `('buildin', 'list')`. Then, when processing the `list_of_dict` field, the same deserializer will be taken from the cache because of the same key, and result in error.